### PR TITLE
Fix output processing for multiple polychord grade_dims

### DIFF
--- a/nestcheck/data_processing.py
+++ b/nestcheck/data_processing.py
@@ -396,23 +396,24 @@ def process_polychord_stats(file_root, base_dir):
     output['nposterior'] = int(lines[20 + nclust].split()[1])
     output['nequals'] = int(lines[21 + nclust].split()[1])
     output['ndead'] = int(lines[22 + nclust].split()[1])
+    
     output['nlive'] = int(lines[23 + nclust].split()[1])
     try:
-        output['nlike'] = int(lines[24 + nclust].split()[1])
+        output['nlike'] = [int(x) for x in lines[24 + nclust].split()[1:]]
+        if len(output['nlike']) == 1:
+            output['nlike'] = output['nlike'][0]
     except ValueError:
         # if nlike has too many digits, PolyChord just writes ***** to .stats
         # file. This causes a ValueError
         output['nlike'] = np.nan
+    
     line = lines[25 + nclust].split()
     i = line.index('(')
     output['avnlike'] = [float(x) for x in line[1:i]]
-
     try:
         output['avnlikeslice'] = [float(x) for x in line[i+1:-3]]
     except NameError:
         output['avnlikeslice'] = None
-    # output['avnlike'] = float(lines[25 + nclust].split()[1])
-    # output['avnlikeslice'] = float(lines[25 + nclust].split()[3])
     # Means and stds of dimensions (not produced by PolyChord<=1.13)
     if len(lines) > 29 + nclust:
         output['param_means'] = []

--- a/nestcheck/data_processing.py
+++ b/nestcheck/data_processing.py
@@ -403,8 +403,16 @@ def process_polychord_stats(file_root, base_dir):
         # if nlike has too many digits, PolyChord just writes ***** to .stats
         # file. This causes a ValueError
         output['nlike'] = np.nan
-    output['avnlike'] = float(lines[25 + nclust].split()[1])
-    output['avnlikeslice'] = float(lines[25 + nclust].split()[3])
+    line = lines[25 + nclust].split()
+    i = line.index('(')
+    output['avnlike'] = [float(x) for x in line[1:i]]
+
+    try:
+        output['avnlikeslice'] = [float(x) for x in line[i+1:-3]]
+    except NameError:
+        output['avnlikeslice'] = None
+    # output['avnlike'] = float(lines[25 + nclust].split()[1])
+    # output['avnlikeslice'] = float(lines[25 + nclust].split()[3])
     # Means and stds of dimensions (not produced by PolyChord<=1.13)
     if len(lines) > 29 + nclust:
         output['param_means'] = []

--- a/nestcheck/write_polychord_output.py
+++ b/nestcheck/write_polychord_output.py
@@ -7,6 +7,7 @@ dictionary stored in the nestcheck format.
 import copy
 import functools
 import os
+from collections.abc import Iterable
 import numpy as np
 import nestcheck.estimators as e
 import nestcheck.error_analysis
@@ -231,9 +232,14 @@ def write_stats_file(run_output_dict):
         ' nequals:           {0}'.format(output['nequals']),
         ' ndead:          {0}'.format(output['ndead']),
         ' nlive:             {0}'.format(output['nlive']),
-        ' nlike:         {0}'.format(output['nlike']),
+        ' nlike:         {0}'.format(
+            output['nlike'] if not isinstance(output['nlike'], Iterable) 
+            else " ".join([str(x) for x in output['nlike']])),
         ' <nlike>:       {0}   (    {1} per slice )'.format(
-            output['avnlike'], output['avnlikeslice']),
+            output['avnlike'] if not isinstance(output['avnlike'], Iterable) 
+            else " ".join([str(x) for x in output['avnlike']]), 
+            output['avnlikeslice'] if not isinstance(output['avnlikeslice'], Iterable) 
+            else " ".join([str(x) for x in output['avnlikeslice']])),
         '',
         '',
         'Dim No.       Mean        Sigma']


### PR DESCRIPTION
This attempts to fix issue #2. It now parses the `nlike`, `avnlike`, and `avnlikeslices` statistics even when multiple values are present. I also tried to address other instances in the code where these attributes are accessed but that was done pretty much blind without an understanding what the code does. 

dyPolychord now runs with multiple grade_dims but the output is weird: for 2 grade_dims, it reports 4 values for `nlike`, instead of 2 that pypolychord outputs. The sample efficiency also degrades massively (~3 times the number of likelihood evaluations with 2 grade_dims than with 1).