### PR TITLE
Add MANIFEST.in to include .pypi_long_desc.rst to tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include .pypi_long_desc.rst


### PR DESCRIPTION
This PR adds a `MANIFEST.in` file to ensure that the `.pypi_long_desc.rst` file is included in the tarball. Without it, the package cannot be built from the tarball alone, as required for third-party packagers such as `conda`.
