### PR TITLE
fixing process_dynesty_run to work with batch nested sampling

### DIFF
--- a/nestcheck/data_processing.py
+++ b/nestcheck/data_processing.py
@@ -345,13 +345,22 @@ def process_dynesty_run(results):
     except AttributeError:
         # If results has no nlive attribute, it must be dynamic nested sampling
         assert unique_th.shape[0] == sum(results.batch_nlive)
+        is_dynamic_ns = True
+        #numpy diff goes out[i] = samples[i+1] - samples[i], so it records the 
+        #samples added/removed at samples[i]
+        diff_nlive = np.diff(results.samples_n)
+        #results.samples_n tells us how many live samples there are at a given iteration,
+        #so use the diff of this to assign the samples[change_in_nlive_at_sample (col 2)]
+        #value. We know we want the last n_live to end with 1      
+        samples[:-1,2] = diff_nlive
         for th_lab, ind in zip(unique_th, first_inds):
             thread_min_max[th_lab, 0] = (
                 results.batch_bounds[results.samples_batch[ind], 0])
     for th_lab in unique_th:
         final_ind = np.where(results.samples_id == th_lab)[0][-1]
         thread_min_max[th_lab, 1] = results.logl[final_ind]
-        samples[final_ind, 2] = -1
+        if not is_dynamic_ns:
+            samples[final_ind, 2] = -1
     assert np.all(~np.isnan(thread_min_max))
     run = nestcheck.ns_run_utils.dict_given_run_array(samples, thread_min_max)
     nestcheck.ns_run_utils.check_ns_run(run)

--- a/nestcheck/data_processing.py
+++ b/nestcheck/data_processing.py
@@ -334,6 +334,7 @@ def process_dynesty_run(results):
     unique_th, first_inds = np.unique(results.samples_id, return_index=True)
     assert np.array_equal(unique_th, np.asarray(range(unique_th.shape[0])))
     thread_min_max = np.full((unique_th.shape[0], 2), np.nan)
+    is_dynamic_ns = False
     try:
         # Try processing standard nested sampling results
         assert unique_th.shape[0] == results.nlive

--- a/tests/test_data_io.py
+++ b/tests/test_data_io.py
@@ -190,6 +190,7 @@ class TestDataProcessing(unittest.TestCase):
                     self.batch_nlive = np.full(
                         run['thread_min_max'].shape[0], 1)
                     self.samples_batch = run['thread_labels']
+                    self.samples_n = np.ones(shape=(1,self.samples.shape[0]))
 
         run = nestcheck.dummy_data.get_dummy_run(1, 10)
         for dynamic in [True, False]:


### PR DESCRIPTION
As discussed in #8, currently nestcheck fails with dynesty v.2.1.2 when nested sampling is run with batch sampling. I've put in a fix in the process_dynesty_run function so that it correctly initialises the nlive_array with a number of live points that is increased with each subsequent batch. 